### PR TITLE
Resume the AudioContext on the combined-MPD path

### DIFF
--- a/hoast360.js
+++ b/hoast360.js
@@ -97,7 +97,13 @@ export class HOAST360 {
             // had no equivalent anywhere, so it played video with permanently
             // silent audio.
             if (scope.context.state !== 'running')
-                scope.context.resume();
+                scope.context.resume().catch(function (e) {
+                    // resume() rejects on a closed context. Nothing closes this
+                    // one today, so this is a guard rather than a known path,
+                    // but an unhandled rejection here would be silent noise in
+                    // the console exactly when audio is already failing.
+                    console.warn('AudioContext resume failed:', e);
+                });
         });
     }
 

--- a/hoast360.js
+++ b/hoast360.js
@@ -87,6 +87,18 @@ export class HOAST360 {
                 httpSourceSelector: { default: 'auto' }
             }
         });
+
+        let scope = this;
+        this.videoPlayer.on('play', function () {
+            // Autoplay policy: the AudioContext starts suspended, and the play
+            // click is the user gesture allowed to resume it. The
+            // separate-audio-MPD path already gets this via
+            // PlaybackEventHandler; the combined-MPD path (single manifest.mpd)
+            // had no equivalent anywhere, so it played video with permanently
+            // silent audio.
+            if (scope.context.state !== 'running')
+                scope.context.resume();
+        });
     }
 
     initialize(newMediaUrl, newIrUrl, newOrder) {


### PR DESCRIPTION
With a single combined manifest carrying both audio and video (one `manifest.mpd`), playback shows video but is completely silent on first load, on any browser that enforces the autoplay policy: a newly created `AudioContext` starts `suspended` and only a user gesture may resume it.

The player does resume a suspended context on the user's first play action, but that code lives in `PlaybackEventHandler`, which is only initialised on the separate-audio-MPD path:

```js
// playback event handler is only needed if we have separate audio and video players
if (scope.audioPlayer)
    scope.playbackEventHandler.initialize(scope.videoPlayer, scope.audioPlayer);
```

On the combined-MPD path `audioPlayer` is `null`, so nothing ever resumes the context. It stays suspended from construction and the whole HOA graph hanging off it stays silent, with no error anywhere. Video plays normally throughout, which is what makes it look like a stream problem rather than a player one. Anyone serving a single-manifest stream through this player is affected.

The fix resumes on the videojs player's own `play` event, which is itself the qualifying user gesture, so it covers both paths without touching `PlaybackEventHandler`. The separate-audio path is unchanged, since resuming an already-running context is a no-op.

Found and fixed against a combined-MPD deployment, where the path was reliably silent before the change and audio starts on the same gesture as video after it. Rechecked most recently in Firefox 153, Brave 151 and Edge 151 on macOS. That testing was on my fork's build, which has diverged from here (webpack 5, Node 24, a vendored videojs-xr); this branch is the same change applied to current master.
