### PR TITLE
Load each higher-order decoding filter, not copies of the group's first

### DIFF
--- a/dependencies/HoastLoader.js
+++ b/dependencies/HoastLoader.js
@@ -132,7 +132,10 @@ export default class HOASTloader {
         this.hoaBuffer = this.context.createBuffer(nCh - 4, hoalength, srate);
         for (var i = 1; i < nChGroups; i++) {
             for (var j = 0; j < this.buffers[i].numberOfChannels; j++) {
-                this.hoaBuffer.getChannelData((i - 1) * 8 + j).set(this.buffers[i].getChannelData(0));
+                // take channel j of this group, not channel 0: otherwise every
+                // destination in the group receives a copy of the group's FIRST
+                // decoding filter instead of its own
+                this.hoaBuffer.getChannelData((i - 1) * 8 + j).set(this.buffers[i].getChannelData(j));
             }
         }
     }


### PR DESCRIPTION
`HoastLoader.concatBuffers()` reads source channel `0` for every destination channel in a higher-order group, so each group ends up filled with copies of its first channel's decoding filter instead of each channel's own:

```js
this.hoaBuffer.getChannelData((i - 1) * 8 + j).set(this.buffers[i].getChannelData(0));
//                                                                                ^ should be j
```

At 3rd order this affects 10 of the 12 higher-order filter channels: ambisonic 6-12 all receive channel 5's filter, and 14-16 all receive channel 13's. Channels 5 and 13 happen to be right, being first in their groups, and 1-4 are unaffected because the first-order buffer is assigned directly.

Found it during measuring and optimizing codec settings; upon finding this bug, I measured the difference through the `HOASTBinDecoder`, first with a synthetic tone ladder and then on programme material, and wrote it up [here](https://github.com/mormegil6/ambisonic-box/blob/main/aac-bitrate-test/RESULTS.md#a-decoder-defect-had-to-be-fixed-before-any-of-this-was-measurable). Short version: errors of up to about 15 dB on individual channels, and the effect is larger than any codec setting I was comparing at the time.

Source only. `dist/hoast360.bundle.js` is committed in this repo but I have left it alone, since rebuilding it with a different toolchain would bury a four-line change under a regenerated bundle. It needs a rebuild for the fix to reach anyone consuming `dist/` directly.

I have not verified 2nd or 4th order beyond reading the loop, though the same stride covers them.
