### PR TITLE
Read the ambisonic order from the manifest when none is given

### DIFF
--- a/hoast360.js
+++ b/hoast360.js
@@ -104,7 +104,13 @@ export class HOAST360 {
      */
     static async orderFromManifest(mediaUrl) {
         try {
-            const r = await fetch(mediaUrl, { cache: 'no-store' });
+            // mediaUrl is either a combined .mpd or the directory prefix that
+            // initialize() appends audio.mpd/video.mpd to. The channel count
+            // sits on the audio AdaptationSet in both layouts, so resolve to
+            // the audio manifest before fetching rather than fetching a
+            // directory and finding nothing.
+            const url = mediaUrl.includes('.mpd') ? mediaUrl : mediaUrl + 'audio.mpd';
+            const r = await fetch(url, { cache: 'no-store' });
             if (!r.ok) return null;
             const text = await r.text();
             const m = text.match(/audio_channel_configuration[^>]*value="(\d+)"/i)

--- a/hoast360.js
+++ b/hoast360.js
@@ -89,7 +89,48 @@ export class HOAST360 {
         });
     }
 
-    initialize(newMediaUrl, newIrUrl, newOrder) {
+    /**
+     * Read the ambisonic order from a DASH manifest.
+     *
+     * The order is a property of the stream, and the manifest already states
+     * it: every MPD carries AudioChannelConfiguration on the audio
+     * AdaptationSet. Requiring the caller to pass it as well means every
+     * embedder hardcodes a number, and a page serving clips of different
+     * orders has to track which is which out of band.
+     *
+     * Returns null when the manifest cannot be read or states a channel count
+     * that is not a full ambisonic set, so the caller can fall back rather
+     * than silently render at the wrong order.
+     */
+    static async orderFromManifest(mediaUrl) {
+        try {
+            const r = await fetch(mediaUrl, { cache: 'no-store' });
+            if (!r.ok) return null;
+            const text = await r.text();
+            const m = text.match(/audio_channel_configuration[^>]*value="(\d+)"/i)
+                   || text.match(/AudioChannelConfiguration[^>]*value="(\d+)"/);
+            if (!m) return null;
+            // (order + 1)^2 channels: 1st order is 4, 2nd 9, 3rd 16, 4th 25.
+            return ({ 4: 1, 9: 2, 16: 3, 25: 4 })[parseInt(m[1], 10)] ?? null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param newOrder ambisonic order. Omit it (or pass null) to read it from
+     *        the manifest with orderFromManifest().
+     */
+    async initialize(newMediaUrl, newIrUrl, newOrder = null) {
+        if (newOrder === null || newOrder === undefined) {
+            newOrder = await HOAST360.orderFromManifest(newMediaUrl);
+            if (newOrder === null) {
+                this.videoPlayer.error(
+                    'Error: could not read the ambisonic order from the manifest, and none was given.');
+                return;
+            }
+        }
+
         if (!this.opusSupport) {
             this.videoPlayer.error('Error: Your browser does not support the OPUS audio codec. Please use Firefox or Chrome-based browsers.');
             return;


### PR DESCRIPTION
`initialize()` requires the caller to pass the ambisonic order, so every embedder hardcodes a number that the stream already states: each DASH manifest carries `AudioChannelConfiguration` on its audio AdaptationSet.

That is fine for a page serving one fixed clip. It stops being fine as soon as a deployment serves clips of different orders, because the page has to track which is which out of band, and a mismatch renders at the wrong order rather than failing.

`initialize(url, irUrl)` now reads the order when the third argument is omitted, mapping `(order + 1)^2` channels to 1, 2, 3 or 4. Passing an order explicitly still works and skips the fetch, so this is additive and no existing call changes behaviour.

`orderFromManifest()` is exposed as a static in case an embedder wants the value without initialising, and returns `null` rather than guessing when the manifest cannot be fetched or reports a channel count that is not a full ambisonic set. `initialize()` then reports that, instead of defaulting to an order that would be wrong.

Used in production this way on a live 16-channel stream and on 4-channel and 25-channel on-demand clips.