### PR TITLE
Add addCaptions() for WebVTT subtitle tracks

### DIFF
--- a/hoast360.js
+++ b/hoast360.js
@@ -89,6 +89,42 @@ export class HOAST360 {
         });
     }
 
+    /**
+     * Attach WebVTT subtitle tracks to the player.
+     *
+     * Three things make this awkward enough to be worth providing rather than
+     * leaving to each embedder, and all three fail silently:
+     *
+     *  - addRemoteTextTrack does not exist until video.js has finished
+     *    setting the player up, so a call made right after initialize() is
+     *    simply lost. This waits for the player to be ready.
+     *  - a .vtt served from another origin is dropped without a console
+     *    error unless the media element carries crossorigin="anonymous".
+     *    The DASH segments are unaffected, because dash.js fetches those by
+     *    XHR, so the symptom is captions missing while video plays.
+     *  - adding a track does not display it: mode has to be set to
+     *    'showing'. The 'default' flag alone does not do it.
+     *
+     * @param tracks [{ src, lang, label }], first entry shown by default
+     * @param crossOrigin set when the tracks are served from another origin
+     */
+    addCaptions(tracks, crossOrigin = false) {
+        if (!tracks || !tracks.length) return;
+        this.videoPlayer.ready(() => {
+            if (crossOrigin) {
+                const el = this.videoPlayer.el().querySelector('video');
+                if (el) el.setAttribute('crossorigin', 'anonymous');
+            }
+            tracks.forEach((t, i) => {
+                const el = this.videoPlayer.addRemoteTextTrack({
+                    kind: 'captions', src: t.src, srclang: t.lang,
+                    label: t.label, default: i === 0,
+                }, true);
+                if (i === 0 && el && el.track) el.track.mode = 'showing';
+            });
+        });
+    }
+
     initialize(newMediaUrl, newIrUrl, newOrder) {
         if (!this.opusSupport) {
             this.videoPlayer.error('Error: Your browser does not support the OPUS audio codec. Please use Firefox or Chrome-based browsers.');

--- a/hoast360.js
+++ b/hoast360.js
@@ -90,7 +90,7 @@ export class HOAST360 {
     }
 
     /**
-     * Attach WebVTT subtitle tracks to the player.
+     * Attach WebVTT caption tracks to the player.
      *
      * Three things make this awkward enough to be worth providing rather than
      * leaving to each embedder, and all three fail silently:
@@ -105,8 +105,10 @@ export class HOAST360 {
      *  - adding a track does not display it: mode has to be set to
      *    'showing'. The 'default' flag alone does not do it.
      *
-     * @param tracks [{ src, lang, label }], first entry shown by default
-     * @param crossOrigin set when the tracks are served from another origin
+     * @param {Array<{src: string, lang: string, label: string}>} tracks
+     *        first entry is shown by default
+     * @param {boolean} [crossOrigin=false] set when the tracks are served from
+     *        another origin
      */
     addCaptions(tracks, crossOrigin = false) {
         if (!tracks || !tracks.length) return;
@@ -116,11 +118,11 @@ export class HOAST360 {
                 if (el) el.setAttribute('crossorigin', 'anonymous');
             }
             tracks.forEach((t, i) => {
-                const el = this.videoPlayer.addRemoteTextTrack({
+                const trackEl = this.videoPlayer.addRemoteTextTrack({
                     kind: 'captions', src: t.src, srclang: t.lang,
                     label: t.label, default: i === 0,
                 }, true);
-                if (i === 0 && el && el.track) el.track.mode = 'showing';
+                if (i === 0 && trackEl && trackEl.track) trackEl.track.mode = 'showing';
             });
         });
     }


### PR DESCRIPTION
There is no caption path in the player today, and wiring one from outside runs into three failures that are all silent:

- `addRemoteTextTrack` does not exist until video.js has finished setting the player up, so a call made straight after `initialize()` is simply lost.
- A `.vtt` served from another origin is dropped with no console error unless the media element carries `crossorigin="anonymous"`. The DASH segments are unaffected, because dash.js fetches those by XHR, so the symptom is captions missing while the video plays normally.
- Adding a track does not display it. `track.mode` has to be set to `'showing'`; the `default` flag alone does not do it.

Each of those costs an afternoon to find, and none of them produces an error message. `addCaptions(tracks)` handles all three, takes `[{ src, lang, label }]`, and is a no-op when passed nothing, so it changes nothing for players that do not use captions. The `crossOrigin` flag is opt-in because setting the attribute unconditionally would be a behaviour change for same-origin deployments.